### PR TITLE
9 unexp token

### DIFF
--- a/examples/test_errors/test_1.ptx
+++ b/examples/test_errors/test_1.ptx
@@ -1,0 +1,3 @@
+# No newline at end of file
+smth = 'fail'
+print smth

--- a/examples/test_errors/test_2.ptx
+++ b/examples/test_errors/test_2.ptx
@@ -1,0 +1,2 @@
+# Newline right after print
+print

--- a/examples/test_errors/test_3.ptx
+++ b/examples/test_errors/test_3.ptx
@@ -1,0 +1,2 @@
+# An attempt to create variable with reserved name 'print'
+print = 'smth'

--- a/pytux/build/__main__.py
+++ b/pytux/build/__main__.py
@@ -1,6 +1,5 @@
 import pytux.log as log
-from pytux.build.semen import parse
-from pytux.build.lexa import Lexa
+from pytux.build.semen import parse, SemenError
 from os import path
 
 __logger = log.get_logger(__name__)
@@ -27,7 +26,13 @@ def main(argv):
     if argv.file is not None:
         source_file_name = argv.file.name
         result_file_name = path.splitext(source_file_name)[0] + ".rpy"
-        with open(result_file_name, "w") as result_file:
-            result_file.write(parse(argv.file))
+        try:
+            result = parse(argv.file)
+            with open(result_file_name, "w") as result_file:
+                result_file.write(result)
+            print(f"Pytux successfully translated {source_file_name} to {result_file_name}")
+        except SemenError as err:
+            print(f"Syntax error in {source_file_name}, check log via [pytux log show] for details")
+            __logger.error(err)
 
     return 0

--- a/pytux/build/lexa.py
+++ b/pytux/build/lexa.py
@@ -55,7 +55,7 @@ def t_COMMENT(t):
 
 # Error handling rule
 def t_error(t):
-    print("Illegal character '%s'" % t.value[0])
+    print(f"Illegal character '{t.value[0]}'")
     t.lexer.skip(1)
 
 

--- a/pytux/build/semen.py
+++ b/pytux/build/semen.py
@@ -3,6 +3,12 @@ from pytux.build.lexa import tokens, Lexa
 from pytux.build.varya import Varya, VarType
 from os import path
 
+
+class SemenError(Exception):
+    def __str__(self):
+        return f'Syntax error: {super().__str__()}'
+
+
 parsed_file_dir = ''
 
 
@@ -38,7 +44,13 @@ def p_print(p):
 
 # Error rule for syntax errors
 def p_error(p):
-    print("Syntax error in input!")
+    if p is None:
+        raise SemenError("Unexpected end of file")
+    else:
+        if p.type == 'NEWLINE':
+            raise SemenError(f"Unexpected line break on line {p.lineno}")
+        else:
+            raise SemenError(f"Unexpected token ({p.type}, {p.value}) on line {p.lineno}")
 
 
 start = 'program'


### PR DESCRIPTION
I have added some syntax error handling, including typical:

unexpected token
unexpected end of file
_unexpected defecation_
unexpected line break

There is only one problem though and it's related to issue #5: if there is one or more empty lines between comment and _петух_ code, than line number with error can be defined incorrectly...

close #9 